### PR TITLE
AddKaminariGem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,3 +53,4 @@ gem "bootstrap-sass"
 gem "devise"
 gem 'carrierwave'
 gem 'mini_magick'
+gem "kaminari"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,18 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.6)
+    kaminari (1.1.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.1.1)
+      kaminari-activerecord (= 1.1.1)
+      kaminari-core (= 1.1.1)
+    kaminari-actionview (1.1.1)
+      actionview
+      kaminari-core (= 1.1.1)
+    kaminari-activerecord (1.1.1)
+      activerecord
+      kaminari-core (= 1.1.1)
+    kaminari-core (1.1.1)
     loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -214,6 +226,7 @@ DEPENDENCIES
   haml-rails
   jbuilder (~> 2.0)
   jquery-rails
+  kaminari
   mini_magick
   mysql2 (>= 0.3.13, < 0.5)
   pry-rails

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,6 +1,6 @@
 class PrototypesController < ApplicationController
   def index
-    @prototypes = Prototype.all
+    @prototypes = Prototype.includes(:user).order("created_at ASC").page(params[:page]).per(5)
   end
 
   def new

--- a/app/views/kaminari/_first_page.html.haml
+++ b/app/views/kaminari/_first_page.html.haml
@@ -1,0 +1,2 @@
+%li.page-item
+  = link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link'

--- a/app/views/kaminari/_first_page.html.haml
+++ b/app/views/kaminari/_first_page.html.haml
@@ -1,2 +1,5 @@
-%li.page-item
-  = link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link'
+%li.page-item.prev{ class: "#{'disabled' if current_page.first?}" }
+  = link_to (current_page.first? ? "#" : url), class: "page-link", "aria-label" => "First", :remote => remote do
+    %span{"aria-hidden" => "true"} «
+    %span.sr-only
+      = t('views.pagination.first').html_safe

--- a/app/views/kaminari/_gap.html.haml
+++ b/app/views/kaminari/_gap.html.haml
@@ -1,0 +1,2 @@
+%li.page-item.disabled
+  = link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link'

--- a/app/views/kaminari/_last_page.html.haml
+++ b/app/views/kaminari/_last_page.html.haml
@@ -1,0 +1,2 @@
+%li.page-item
+  = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link'

--- a/app/views/kaminari/_last_page.html.haml
+++ b/app/views/kaminari/_last_page.html.haml
@@ -1,2 +1,5 @@
-%li.page-item
-  = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link'
+%li.page-item.next{ class: "#{'disabled' if current_page.last?}" }
+  = link_to (current_page.last? ? "#" : url), class: "page-link", "aria-label" => "Last", :remote => remote do
+    %span{"aria-hidden" => "true"} »
+    %span.sr-only
+      = t('views.pagination.last').html_safe

--- a/app/views/kaminari/_next_page.html.haml
+++ b/app/views/kaminari/_next_page.html.haml
@@ -1,0 +1,2 @@
+%li.page-item
+  = link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link'

--- a/app/views/kaminari/_page.html.haml
+++ b/app/views/kaminari/_page.html.haml
@@ -1,0 +1,6 @@
+- if page.current?
+  %li.page-item.active
+    = content_tag :a, page, data: { remote: remote }, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)), class: 'page-link'
+- else
+  %li.page-item
+    = link_to page, url, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)), class: 'page-link'

--- a/app/views/kaminari/_paginator.html.haml
+++ b/app/views/kaminari/_paginator.html.haml
@@ -1,0 +1,12 @@
+= paginator.render do
+  %nav
+    %ul.pagination
+      = first_page_tag unless current_page.first?
+      = prev_page_tag unless current_page.first?
+      - each_page do |page|
+        - if page.left_outer? || page.right_outer? || page.inside_window?
+          = page_tag page
+        - elsif !page.was_truncated?
+          = gap_tag
+      = next_page_tag unless current_page.last?
+      = last_page_tag unless current_page.last?

--- a/app/views/kaminari/_paginator.html.haml
+++ b/app/views/kaminari/_paginator.html.haml
@@ -1,12 +1,12 @@
 = paginator.render do
   %nav
     %ul.pagination
-      = first_page_tag unless current_page.first?
-      = prev_page_tag unless current_page.first?
+      = first_page_tag
+      / = prev_page_tag unless current_page.first?
       - each_page do |page|
         - if page.left_outer? || page.right_outer? || page.inside_window?
           = page_tag page
         - elsif !page.was_truncated?
           = gap_tag
-      = next_page_tag unless current_page.last?
-      = last_page_tag unless current_page.last?
+      / = next_page_tag unless current_page.last?
+      = last_page_tag

--- a/app/views/kaminari/_prev_page.html.haml
+++ b/app/views/kaminari/_prev_page.html.haml
@@ -1,0 +1,2 @@
+%li.page-item
+  = link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link'

--- a/app/views/prototypes/index.html.haml
+++ b/app/views/prototypes/index.html.haml
@@ -17,6 +17,9 @@
     = render partial: "prototype", collection: @prototypes
 
 .text-center
+  =paginate(@prototypes)
+
+.text-center
   %ul.pagination
     %li.disabled
       %a{"aria-label": "Previous", href: "#"}

--- a/app/views/prototypes/index.html.haml
+++ b/app/views/prototypes/index.html.haml
@@ -17,25 +17,5 @@
     = render partial: "prototype", collection: @prototypes
 
 .text-center
-  =paginate(@prototypes)
-
-.text-center
-  %ul.pagination
-    %li.disabled
-      %a{"aria-label": "Previous", href: "#"}
-        %span{"aria-hidden": "true"} «
-    %li.active
-      %a{href: "#"}
-        1
-        %span.sr-only (current)
-    %li
-      %a{href: "#"} 2
-    %li
-      %a{href: "#"} 3
-    %li
-      %a{href: "#"} 4
-    %li
-      %a{href: "#"} 5
-    %li
-      %a{"aria-label": "Next", href: "#"}
-        %span{"aria-hidden": "true"} »
+  -# 『window: 3』と追記することで、数字以降のページは省略『...』となる。
+  =paginate @prototypes, window: 3


### PR DESCRIPTION
# what
- ページ送り機能の導入。
# why
- UX向上

-----------------------------------------------
## 概要
- 一覧で表示しているプロトタイプの数を制限した方が読み込みの速度があがり、ユーザーにとって便利です。

## 主な使用技術
- gem kaminari

## 完了の定義
- ページ送り機能が機能している