### PR TITLE
AddJavaScriptForPreviewOfImage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,6 @@
 
 *.jpeg
 
+*.ico
+
 config/cloudinary.yml

--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@
 - 未定
 
 ## 特記事項
-- 現段階では特に無し。
-
+- ローカル環境で実行する際、cloudinaryに関する記述の影響でエラーが生じるため、実行する際は下記３つを解除する。
+  ・『gem "cloudinary"』を削除
+  ・2つのimage_uploader.rbファイルについて、画像の保存先を『storage :file』のみにする、production、depelopment環境問わず。（7~11行目）
+  ・
 
 # Structure of DataBase
 

--- a/app/assets/javascripts/prototype.js
+++ b/app/assets/javascripts/prototype.js
@@ -1,12 +1,45 @@
 $(function(){
   //画像ファイルプレビュー表示のイベント追加 fileを選択時に発火するイベントを登録
   $('form').on('change', 'input[type="file"]', function(e) {
+    // 『e.target』でイベントが発生したDOM要素を取得。
+    // イベントは要素を伝わって移動する為。兄弟や子孫ではなく、親へ伝わる。
+    // 『.files』で選択ファイルを配列形式で取得。（『FileList』となっている。）
+    // [0]を付加する事で、その中の『File』について取り出すことが可能。
     var file = e.target.files[0],
-        reader = new FileReader(),
-        $preview = $("#main_preview");
+        // オブジェクトを生成
+        reader = new FileReader();
+        // １：$preview = $("#main_preview");
         t = this;
 
-    // 画像ファイル以外の場合は何もしない
+    //ページ内、すべてに対応させる為に記述。
+    // ①hamlを書き換え、ファイルを選択する要素の次兄弟に画像を差し込む要素を設定。
+    // ②次兄弟な為、『next~』で差し込む箇所の要素を取得し、取得物からjQueryオブジェクト を生成。
+    // ③生成した箇所に対して処理を行う。（47行目あたり）
+    // ※場所が固定されている場合処理が『１：』
+    var sibling = e.target.nextElementSibling;
+    var sibling_object = new jQuery.fn.init(sibling, undefined, $(document));
+    // console.log(sibling);
+    // console.log(sibling_object);
+
+    //id名から要素（DOM）を取得の方法（『sibling』が同等の為、不要）
+    // var sibling_id = sibling.id;
+    // var dom_element = document.getElementById(sibling_id);
+    // var sibling_object = new jQuery.fn.init(dom_element, undefined, $(document));
+
+    //使用しているものの確認用
+    // console.log(e.target);
+    // console.log(file);
+    // console.log(file.type);
+    // console.log(file.type.indexOf("image"));
+
+    //１：『$("クラス・id名")』で何が生成されるのか、確認用
+    // console.log($preview);
+    // var example = new jQuery.fn.init($preview, undefined, $(document));
+    // console.log(example);
+
+    // 画像ファイルかの判定
+    //  『indexOf(引数)』引数で与えた文字列より前に何文字あるか値を返す。
+    //   最初の場合、0が返り、存在しない場合は−１が返る。
     if(file.type.indexOf("image") < 0){
       return false;
     }
@@ -15,9 +48,12 @@ $(function(){
     reader.onload = (function(file) {
       return function(e) {
         // 既存のプレビューを削除
-        $preview.empty();
-        // 領域の中にロードした画像を表示するimageタグを追加
-        $preview.append($('<img>').attr({
+        sibling_object.empty();
+        // １：$preview.empty();
+        // 領域の中に画像を表示するimageタグを追加
+        sibling_object.append($('<img>').attr({
+        // １：$preview.append($('<img>').attr({
+                  // ロードされた画像ファイルのData URIスキームの格納場所
                   src: e.target.result,
                   id: "main_preview",
                   title: file.name

--- a/app/assets/javascripts/prototype.js
+++ b/app/assets/javascripts/prototype.js
@@ -1,4 +1,4 @@
-$(function(){
+$(document).on("turbolinks:load", function() {
   //画像ファイルプレビュー表示のイベント追加 fileを選択時に発火するイベントを登録
   $('form').on('change', 'input[type="file"]', function(e) {
     // 『e.target』でイベントが発生したDOM要素を取得。

--- a/app/assets/javascripts/prototype.js
+++ b/app/assets/javascripts/prototype.js
@@ -1,0 +1,30 @@
+$(function(){
+  //画像ファイルプレビュー表示のイベント追加 fileを選択時に発火するイベントを登録
+  $('form').on('change', 'input[type="file"]', function(e) {
+    var file = e.target.files[0],
+        reader = new FileReader(),
+        $preview = $("#main_preview");
+        t = this;
+
+    // 画像ファイル以外の場合は何もしない
+    if(file.type.indexOf("image") < 0){
+      return false;
+    }
+
+    // ファイル読み込みが完了した際のイベント登録
+    reader.onload = (function(file) {
+      return function(e) {
+        // 既存のプレビューを削除
+        $preview.empty();
+        // 領域の中にロードした画像を表示するimageタグを追加
+        $preview.append($('<img>').attr({
+                  src: e.target.result,
+                  id: "main_preview",
+                  title: file.name
+              }));
+      };
+    })(file);
+
+    reader.readAsDataURL(file);
+  });
+});

--- a/app/assets/stylesheets/prototypes.scss
+++ b/app/assets/stylesheets/prototypes.scss
@@ -671,10 +671,25 @@ body {
   }
 }
 
-#main_preview,
-#sub_1_preview,
-#sub_2_preview,
-#sub_3_preview {
-  height: 100%;
-  width: 100%;
+// #main_preview,
+// #sub_1_preview,
+// #sub_2_preview,
+// #sub_3_preview {
+//   height: 100%;
+//   width: 100%;
+// }
+
+.cover-image-upload {
+  #main_preview img {
+    height: 500px;
+    width: 730px;
+  }
+}
+.image-upload {
+  #sub_1_preview img,
+  #sub_2_preview img,
+  #sub_3_preview img {
+    height: 200px;
+    width: 213px;
+  }
 }

--- a/app/assets/stylesheets/prototypes.scss
+++ b/app/assets/stylesheets/prototypes.scss
@@ -671,7 +671,10 @@ body {
   }
 }
 
-#main_preview {
+#main_preview,
+#sub_1_preview,
+#sub_2_preview,
+#sub_3_preview {
   height: 100%;
   width: 100%;
 }

--- a/app/assets/stylesheets/prototypes.scss
+++ b/app/assets/stylesheets/prototypes.scss
@@ -670,3 +670,8 @@ body {
     margin-right: 5px;
   }
 }
+
+#main_preview {
+  height: 100%;
+  width: 100%;
+}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,6 +7,7 @@ class UsersController < ApplicationController
 
   def show
     @prototypes = @user.prototypes.includes(:user).order("created_at ASC").page(params[:page]).per(5)
+    @prototypes_count = @user.prototypes.includes(:user).length
   end
 
   def edit

--- a/app/views/prototypes/edit.html.haml
+++ b/app/views/prototypes/edit.html.haml
@@ -12,16 +12,19 @@
             -# 『:captured_images』の後にインスタンス変数を記載することで、コントローラから値を呼び出している。
             -# 呼び出している値は、新規作成時に保存したもの。
             = image.hidden_field :status, value: "main"
-            = image.file_field :content, required: true
+            = image.file_field :content
+            -# 『required: true』を削除（DBから値を呼んでいるが、再添付アナウンスが出る為）
             #main_preview
+              = image_tag(@main.content)
       .col-md-12
         %ul.proto-sub-list.list-group
           - 3.times do |i|
             -# この中の処理を3回実施する、ifルート、elseルート含めて。
             %li.list-group-item.col-md-4
-              - if @subs
+              - @sub = @subs[i]
+              - unless @sub.nil?
+                / true
                 -# 条件分岐を入れることで既存の更新、もしくは新規追加かを切り分ける
-                - @sub = @subs[i]
                 -# 『@subs』は配列なので、展開する。
                 .image-upload
                   = f.fields_for :captured_images, @sub do |image|
@@ -29,7 +32,9 @@
                     = image.hidden_field :status, value: "sub"
                     = image.file_field :content
                     %div{id: "sub_#{i+1}_preview"}
+                      = image_tag(@sub.content)
               - else
+                / false
                 -# 新規追加時（ビューのnewと同じ原理）
                 .image-upload
                   = f.fields_for :captured_images do |image|

--- a/app/views/prototypes/edit.html.haml
+++ b/app/views/prototypes/edit.html.haml
@@ -11,9 +11,9 @@
           = f.fields_for :captured_images, @main do |image|
             -# 『:captured_images』の後にインスタンス変数を記載することで、コントローラから値を呼び出している。
             -# 呼び出している値は、新規作成時に保存したもの。
-            %img
-            = image.file_field :content, required: true
             = image.hidden_field :status, value: "main"
+            = image.file_field :content, required: true
+            #main_preview
       .col-md-12
         %ul.proto-sub-list.list-group
           - 3.times do |i|
@@ -26,17 +26,17 @@
                 .image-upload
                   = f.fields_for :captured_images, @sub do |image|
                     / = f.fields_for :captured_images, @prototype.captured_images.where(status: 1) do |image|
-                    %img
-                    = image.file_field :content
                     = image.hidden_field :status, value: "sub"
+                    = image.file_field :content
+                    %div{id: "sub_#{i+1}_preview"}
               - else
                 -# 新規追加時（ビューのnewと同じ原理）
                 .image-upload
                   = f.fields_for :captured_images do |image|
                     / = f.fields_for :captured_images, @prototype.captured_images.where(status: 1) do |image|
-                    %img
-                    = image.file_field :content
                     = image.hidden_field :status, value: "sub"
+                    = image.file_field :content
+                    %div{id: "sub_#{i+1}_preview"}
           -# 静的ページ時の記述を残す（３つ目がアイコン『+』で表示されていたので）
             %li.list-group-item.col-md-4
               .image-upload

--- a/app/views/prototypes/new.html.haml
+++ b/app/views/prototypes/new.html.haml
@@ -15,9 +15,9 @@
           = f.fields_for :captured_images do |image|
             -# コントローラ側でインスタンスを生成していない場合は下記の書き方
             -# = f.fields_for :captured_images, @prototype.captured_images.build do |image|
-            %img
             = image.file_field :content, required: true
             = image.hidden_field :status, value: "main"
+            #main_preview
       .col-md-12
         %ul.proto-sub-list.list-group
           -# サブ画像は３つまでの為、このように記述する（コントローラ側で設定してない為）

--- a/app/views/prototypes/new.html.haml
+++ b/app/views/prototypes/new.html.haml
@@ -15,8 +15,8 @@
           = f.fields_for :captured_images do |image|
             -# コントローラ側でインスタンスを生成していない場合は下記の書き方
             -# = f.fields_for :captured_images, @prototype.captured_images.build do |image|
-            = image.file_field :content, required: true
             = image.hidden_field :status, value: "main"
+            = image.file_field :content, required: true
             #main_preview
       .col-md-12
         %ul.proto-sub-list.list-group
@@ -27,9 +27,9 @@
                 = f.fields_for :captured_images do |image|
                   -# コントローラ側でインスタンスを生成していない場合は下記の書き方
                   -# = f.fields_for :captured_images, @prototype.captured_images.build do |image|
-                  %img
-                  = image.file_field :content
                   = image.hidden_field :status, value: "sub"
+                  = image.file_field :content
+                  %div{id: "sub_#{i+1}_preview"}
           -# 静的ページ時の記述を残す（３つ目がアイコン『+』で表示されていたので）
             %li.list-group-item.col-md-4
               .image-upload

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -11,7 +11,7 @@
         %h4#top-aligned-media.media-heading
           Top aligned media
           %span.label.label-default.project-number
-            = @prototypes.count
+            = @prototypes_count
             %i Projects
         .proto-user
           %span.degree #{@user.position}


### PR DESCRIPTION
# what
- 投稿機能において、画像を選択した後、プレビューが表示されるようにする。
# why
- UX向上、利便性の為。
-----------------------------------------------
## 概要
現在、投稿機能を実現している部分は、一度選択しても何も起こらない。これを、投稿した画像がプレビューできる形の方が自然。

## 主な使用技術
- Javascript
- jQuery

## 完了の定義
- プロトタイプ投稿時に画像を設定すると、直後に投稿画面にアップロードする画像のプレビューが出る。
- 編集機能の際にも、同様にプレビューが出るようにする。