### PR TITLE
CreateNewest&PopularFunction

### DIFF
--- a/app/assets/stylesheets/newests.scss
+++ b/app/assets/stylesheets/newests.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the newests controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/newests_controller.rb
+++ b/app/controllers/newests_controller.rb
@@ -1,4 +1,5 @@
 class NewestsController < ApplicationController
   def index
+    @prototypes = Prototype.includes(:user).order("created_at DESC").page(params[:page]).per(5)
   end
 end

--- a/app/controllers/newests_controller.rb
+++ b/app/controllers/newests_controller.rb
@@ -1,0 +1,4 @@
+class NewestsController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,7 +1,8 @@
 class PrototypesController < ApplicationController
   before_action :set_prototype, only: [:show, :edit, :update, :destroy]
   def index
-    @prototypes = Prototype.includes(:user).order("created_at ASC").page(params[:page]).per(5)
+    # Popularを表示する為に、DESC用のカラムを変更
+    @prototypes = Prototype.includes(:user).order("likes_count DESC").page(params[:page]).per(5)
   end
 
   def new

--- a/app/views/newests/index.html.haml
+++ b/app/views/newests/index.html.haml
@@ -1,0 +1,8 @@
+= render partial: "prototypes/header_prototype"
+
+.container.proto-list
+  .row
+    = render partial: "prototypes/prototype", collection: @prototypes
+
+.text-center
+  =paginate @prototypes, window: 3

--- a/app/views/prototypes/_header_prototype.html.haml
+++ b/app/views/prototypes/_header_prototype.html.haml
@@ -6,8 +6,10 @@
   .container
     .row
       %ul.nav.nav-pills.col-lg-11
-        %li.active{role: "presentation"}
-          %a{href: "#"} Popular PROTO
-        %li{role: "presentation"}
-          %a{href: "#"} Newest PROTO
+        / 『current_page?(引数)』により、表示中のページを判定することが可能。
+        / 『&&』以降に記述した名称をクラスに追加することができる。
+        %li{role: "presentation", class: current_page?(root_path) && "active"}
+          = link_to "Popular PROTO", root_path
+        %li{role: "presentation", class: current_page?(newests_path) && "active"}
+          = link_to "Newest PROTO", newests_path
       = link_to "View Tags", tags_path , class: "btn btn-default col-lg-1"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,28 @@
 Rails.application.routes.draw do
   devise_for :users
   root "prototypes#index"
+  # root "prototypes#index", path: "popular"
+
+  # 『prototypes』以降に記述してしまうと、url打ち込み時に『/prototypes/:id』の方が先に来て、prototype#showへアクセスしてしまう。
+  resources :newests, path: "prototypes/newest", only: :index
 
   # 『root』でindexを設定している為、下記にindexは不要となる。
   resources :prototypes, except: :index do
     resources :comments, only: :create
     resources :likes, only: [:create, :destroy]
   end
+
+  # 通常のルーティング記載
+  # resources :newests, only: :index
+  # リソースベースで呼び出すコントローラ＆アクションに対して、URLを変更する場合
+  # URLヘルパーの名前は変わらない。
+  # resources :newests, path: "prototypes/newest", only: :index
+  # 『controller:』の記述でも書くことが可能（URLヘルパーの名前は変わる）
+
+  # namespace :prototypes do
+  #   resources :newests, path: "newest", only: :index
+  # end
+
   # 『param: :name』を記載することで、『:id』部分の変更が可能。
   # 下記の方法以外に、『to_param』をモデルに定義する方法もある。
   resources :tags, param: :name, only: [:index, :show]


### PR DESCRIPTION
# what
- トップページにて、投稿最新順とlikeの多い順に並べ変えて表示する機能。
# why
- サービスの盛り上がり＆UX向上の為。
-----------------------------------------------
## 概要
- プロトタイプを、最新/人気順に並び替えられる

## 完了の定義
- 「最新/人気」のボタンを押して、プロトタイプの投稿の順番が切り替わるようにする
- ~~Ajaxで切り替える~~
　→一旦無しの方向で。
